### PR TITLE
release: bump website to v4.11.0 (#1825 in sceneview/sceneview)

### DIFF
--- a/embed/index.html
+++ b/embed/index.html
@@ -10,7 +10,7 @@
 
   <!-- SceneView.js — Filament PBR renderer -->
   <script src="../js/filament/filament.js"></script>
-  <script src="../js/sceneview.js?v=4.4.0"></script>
+  <script src="../js/sceneview.js?v=4.11.0"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.html
+++ b/index.html
@@ -476,7 +476,7 @@
 <span class="syn-green">// Add in Xcode: File &rarr; Add Package Dependencies</span>
 
 <span class="syn-green-light">"https://github.com/sceneview/sceneview"</span>
-<span class="syn-green">// Version: 4.3.4</span>
+<span class="syn-green">// Version: 4.11.0</span>
 
 <span class="syn-purple">import</span> SceneViewSwift</code></pre>
           </div>
@@ -1298,7 +1298,7 @@
                 <span class="cta__terminal-cmd">npm install sceneview-mcp</span>
               </div>
               <div class="cta__terminal-output">
-                + sceneview-mcp@4.0.12<br>
+                + sceneview-mcp@4.11.0<br>
                 added 12 packages from 8 contributors and audited 42 packages in 1.2s<br>
                 <br>
                 <span class="cta__terminal-success">Success!</span> Ready to use SceneView in your project.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament, ARCore) and Apple platforms — iOS, macOS, visionOS (SwiftUI, RealityKit, ARKit) — with shared core logic via Kotlin Multiplatform. Each platform uses its native renderer: Filament on Android, RealityKit on Apple.
 
-**Android — Maven artifacts (version 4.0.9):**
+**Android — Maven artifacts (version 4.11.0):**
 - 3D only: `io.github.sceneview:sceneview:4.11.0`
 - AR + 3D: `io.github.sceneview:arsceneview:4.11.0`
 
@@ -2443,7 +2443,7 @@ ferrari_f40.glb
 
 ## SceneView Web (Kotlin/JS + Filament.js)
 
-Package: `sceneview-web` v4.0.9 — npm `sceneview-web`
+Package: `sceneview-web` v4.11.0 — npm `sceneview-web`
 Renderer: **Filament.js (WebGL2/WASM)** — same Filament engine as SceneView Android, compiled to WebAssembly.
 Requires: Chrome 79+, Edge 79+, Firefox 78+ (WebGL2). Safari 15+ (WebGL2).
 
@@ -2455,7 +2455,7 @@ npm install sceneview-web filament
 Script-tag usage (no bundler):
 ```html
 <script src="https://sceneview.github.io/js/filament/filament.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.11.0/sceneview-web.js"></script>
 ```
 
 After loading, the library registers itself on `window.sceneview`.
@@ -3249,7 +3249,7 @@ Backpressure is absorbed by `rateHz`. Wire format: JSON-lines consumed by
 | visionOS | RealityKit | SwiftUI | via SceneViewSwift | Alpha |
 | Web | Filament.js + WebXR | Kotlin/JS | `samples/web-demo` | Alpha |
 
-SceneView Web (sceneview-web v4.0.9) — see "## SceneView Web (Kotlin/JS + Filament.js)" section above for the full API reference.
+SceneView Web (sceneview-web v4.11.0) — see "## SceneView Web (Kotlin/JS + Filament.js)" section above for the full API reference.
 | Desktop | Software renderer | Compose Desktop | `samples/desktop-demo` | Alpha |
 | Flutter | Filament/RealityKit | PlatformView | `samples/flutter-demo` | Alpha |
 | React Native | Filament/RealityKit | Fabric | `samples/react-native-demo` | Alpha |

--- a/playground.html
+++ b/playground.html
@@ -3498,9 +3498,9 @@
 
         var prompt = 'Build me a SceneView ' + platLabel + ' app:\n\n' + userDesc + '\n\n';
         prompt += '--- SceneView Quick Reference ---\n';
-        prompt += 'SDK: io.github.sceneview:sceneview:4.11.0 (3D) / arsceneview:4.3.1 (AR)\n';
+        prompt += 'SDK: io.github.sceneview:sceneview:4.11.0 (3D) / arsceneview:4.11.0 (AR)\n';
         prompt += 'iOS: SPM https://github.com/sceneview/sceneview.git (from: "4.11.0")\n';
-        prompt += 'Web: npm install sceneview-web@4.3.1\n\n';
+        prompt += 'Web: npm install sceneview-web@4.11.0\n\n';
 
         if (plat === 'android' || plat === 'flutter' || plat === 'reactnative' || plat === 'desktop') {
           prompt += 'Key composables: SceneView { }, ARSceneView { }\n';

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "4.11.0",
-  "build": "2026-05-20T13:49:21Z",
+  "build": "2026-05-20T18:10:59Z",
   "url": "https://github.com/sceneview/sceneview/releases/tag/v4.11.0",
   "notes": "https://github.com/sceneview/sceneview/blob/main/CHANGELOG.md"
 }

--- a/web-demo/version.json
+++ b/web-demo/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.9.0",
-  "url": "https://github.com/sceneview/sceneview/releases/tag/v4.9.0",
+  "version": "4.11.0",
+  "url": "https://github.com/sceneview/sceneview/releases/tag/v4.11.0",
   "notes": "https://github.com/sceneview/sceneview/blob/main/CHANGELOG.md"
 }

--- a/web.html
+++ b/web.html
@@ -766,7 +766,7 @@
     "url": "https://sceneview.github.io/web.html",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Web",
-    "softwareVersion": "4.4.0",
+    "softwareVersion": "4.11.0",
     "license": "https://github.com/sceneview/sceneview/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "author": {


### PR DESCRIPTION
Closes sceneview/sceneview#1825 part 1 — public site was 11 versions stale (softwareVersion 4.0.9 → 4.11.0).

The release.yml auto-update of this sister repo is the part-2 follow-up (see issue).

## Stale version refs synced to 4.11.0

- `index.html` — SPM `// Version: 4.3.4` → 4.11.0; npm install terminal output `sceneview-mcp@4.0.12` → 4.11.0
- `web.html` — schema.org `softwareVersion: 4.4.0` → 4.11.0
- `playground.html` — `arsceneview:4.3.1` → 4.11.0; `npm install sceneview-web@4.3.1` → 4.11.0
- `embed/index.html` — `sceneview.js?v=4.4.0` → 4.11.0
- `web-demo/version.json` — `4.9.0` → 4.11.0
- `llms.txt` — 3 stale `v4.0.9` mentions + `sceneview-web@4.1.0` CDN URL → 4.11.0
- `version.json` — refresh build timestamp to nudge GitHub Pages

## Why content was already at 4.11.0 but live still shows 4.0.9

The tracked content in this repo matches `sceneview/sceneview` `website-static/` byte-for-byte (verified via md5 / diff). The 9 commits on `main` since 2026-05-07 (including the v4.11.0 release deploy) were pushed but GitHub Pages has not produced a build since `2e16035c` (2026-05-07). The `version.json` build-timestamp bump in this PR is to trigger a fresh Pages build alongside the residual in-page string fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)